### PR TITLE
Omit an old RBL

### DIFF
--- a/check_rbl.py
+++ b/check_rbl.py
@@ -35,7 +35,6 @@ serverlist = [
 "b.barracudacentral.org",
 "bhnc.njabl.org",
 "bl.deadbeef.com",
-"bl.emailbasura.org",
 "bl.spamcannibal.org",
 "bl.spamcop.net",
 "bl.technovision.dk",


### PR DESCRIPTION
Save a little execution time (which is so need in Nagios plugin execution) omitting an old and now offline RBL
